### PR TITLE
Add support for checking RSSI

### DIFF
--- a/TelenorNBIoT.cpp
+++ b/TelenorNBIoT.cpp
@@ -28,6 +28,7 @@
 #define REBOOT "NRB"
 #define RADIO_ON "CFUN=1"
 #define RADIO_OFF "CFUN=0"
+#define SIGNAL_STRENGTH "CSQ"
 #define CONNECT_DATA "CGATT=1"
 #define DEFAULT_TIMEOUT 2000
 
@@ -166,6 +167,28 @@ bool TelenorNBIoT::offline()
         return true;
     }
     return false;
+}
+
+int TelenorNBIoT::rssi()
+{
+    int rssi = 99;
+    writeCommand(SIGNAL_STRENGTH);
+    int ret = readCommand(lines);
+    if (ret != 2 || !isOK(lines[1]))
+    {
+        return rssi;
+    }
+    char* fields[2];
+    int found = splitFields(lines[0] + 6, fields);
+    if (found != 1)
+    {
+        return rssi;
+    }
+    rssi = atoi(fields[0]);
+    if (rssi == 99) {
+      return rssi;
+    }
+    return -113 + rssi * 2;
 }
 
 void TelenorNBIoT::addHeader()

--- a/TelenorNBIoT.h
+++ b/TelenorNBIoT.h
@@ -121,6 +121,16 @@ class TelenorNBIoT
     bool reboot();
 
     /**
+     * Returns the Received Signal Strength Indication from the mobile terminal.
+     * In dedicated mode, during the radio channel reconfiguration (e.g.
+     * handover), invalid measurements may be returned for a short transitory
+     * because the mobile terminal must compute them on the newly assigned
+     * channel.
+     * Returns 99 if RSSI is not detectable
+     */
+    int rssi();
+
+    /**
      * Helper function to convert IMSI and IMEI strings into 64 bit integers.
      */
     unsigned long long atoi64(const char *str);


### PR DESCRIPTION
Implementation of the `CSQ` command. Ignoring `<qual>`, since it's always `99` for SARA-N2.

Details about the command in the [SARA-N2 AT Commands Manual](https://www.u-blox.com/sites/default/files/SARA-N2_ATCommands_%28UBX-16014887%29.pdf) Chapter 5.1.