### PR TITLE
Fix: Resolve to 15 minutes delay for all compilers.

### DIFF
--- a/examples/hello/hello.ino
+++ b/examples/hello/hello.ino
@@ -74,7 +74,7 @@ void loop() {
     }
 
     // Wait 15 minutes before sending again
-    delay(15 * 60 * 1000);
+    delay(1UL * 15*60*1000);
   } else {
     // Not connected yet. Wait 5 seconds before retrying.
     Serial.println("Connecting...");


### PR DESCRIPTION
Arithmetic compiler issue, at least using Arduino IDE.
The compiler treats an "integer literal" (e.g. 60 or 1000) as an
"int", not as a long.
Resulting in 15 * 60 * 1000 = -17504 (int) = 4294949792 (unsigned long)
Which is a tad more than 15 minutes...