### PR TITLE
Drop newline after AT-command

### DIFF
--- a/TelenorNBIoT.cpp
+++ b/TelenorNBIoT.cpp
@@ -18,7 +18,7 @@
 #include <Udp.h>
 
 #define PREFIX "AT+"
-#define POSTFIX "\r\n"
+#define POSTFIX "\r"
 #define SOCR "NSOCR=\"DGRAM\",17,%d,1"
 #define SOSTF "NSOSTF="
 #define SOCL "NSOCL=%d"


### PR DESCRIPTION
The u-blox N2 actually only cares about `\r` after an AT-command, and for some commands start replying before it's received a `\n` character. So it's better to not send the `\n` at all.

Screenshot of u-blox starting the reply before receiving the `\n` character using a Saleae Logic Pro 8 sniffing RX and TX between an Arduino MKR Zero and the EE-NBIOT-01:
![newline-char-ignored](https://user-images.githubusercontent.com/149725/51592595-4fb8b480-1ef0-11e9-9b71-a8d8b21e734e.png)