### PR TITLE
Auto-retry for imsi and imei methods

### DIFF
--- a/TelenorNBIoT.cpp
+++ b/TelenorNBIoT.cpp
@@ -163,7 +163,7 @@ bool TelenorNBIoT::isRegistering()
 
 String TelenorNBIoT::imei()
 {
-    if (strnlen(_imei, sizeof _imei) != 15)
+    while (strnlen(_imei, sizeof _imei) != 15)
     {
         writeCommand(IMEI);
         if (readCommand(lines) == 2 && isOK(lines[1]))
@@ -172,19 +172,27 @@ String TelenorNBIoT::imei()
             char *ptr = lines[0] + 7;
             memcpy(_imei, ptr, strnlen(ptr, 15) + 1);
         }
+        else
+        {
+            delay(100);
+        }
     }
     return String(_imei);
 }
 
 String TelenorNBIoT::imsi()
 {
-    if (strnlen(_imsi, sizeof _imsi) != 15)
+    while (strnlen(_imsi, sizeof _imsi) != 15)
     {
         writeCommand(IMSI);
         if (readCommand(lines) == 2 && isOK(lines[1]))
         {
             // Line contains IMSI ("<15 digit IMSI>")
             memcpy(_imsi, lines[0], strnlen(lines[0], 15) + 1);
+        }
+        else
+        {
+            delay(100);
         }
     }
     return String(_imsi);

--- a/TelenorNBIoT.cpp
+++ b/TelenorNBIoT.cpp
@@ -13,6 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+#include <functional>
 #include "TelenorNBIoT.h"
 #include <Arduino.h>
 #include <Udp.h>
@@ -36,6 +37,7 @@
 #define DEFAULT_TIMEOUT 2000
 
 int splitFields(char *line, char **fields, uint8_t maxFields);
+bool retry(uint8_t attempts, std::function<bool ()> fn, uint16_t delayBetween = 100);
 
 TelenorNBIoT::TelenorNBIoT(String accessPointName, uint16_t mobileCountryCode, uint16_t mobileNetworkCode)
 {
@@ -163,37 +165,40 @@ bool TelenorNBIoT::isRegistering()
 
 String TelenorNBIoT::imei()
 {
-    while (strnlen(_imei, sizeof _imei) != 15)
+    if (strnlen(_imei, sizeof _imei) != 15)
     {
-        writeCommand(IMEI);
-        if (readCommand(lines) == 2 && isOK(lines[1]))
-        {
-            // Line 1 contains IMEI ("+CGSN: <15-digit IMEI>")
-            char *ptr = lines[0] + 7;
-            memcpy(_imei, ptr, strnlen(ptr, 15) + 1);
-        }
-        else
-        {
-            delay(100);
-        }
+        retry(10, [this]() {
+            writeCommand(IMEI);
+            if (readCommand(lines) == 2 && isOK(lines[1]))
+            {
+                // Line 1 contains IMEI ("+CGSN: <15-digit IMEI>")
+                char *ptr = lines[0] + 7;
+                if (strnlen(ptr, 16) == 15) {
+                    memcpy(_imei, ptr, 16);
+                    return true;
+                }
+            }
+            
+            return false;
+        });
     }
     return String(_imei);
 }
 
 String TelenorNBIoT::imsi()
 {
-    while (strnlen(_imsi, sizeof _imsi) != 15)
+    if (strnlen(_imsi, sizeof _imsi) != 15)
     {
-        writeCommand(IMSI);
-        if (readCommand(lines) == 2 && isOK(lines[1]))
-        {
-            // Line contains IMSI ("<15 digit IMSI>")
-            memcpy(_imsi, lines[0], strnlen(lines[0], 15) + 1);
-        }
-        else
-        {
-            delay(100);
-        }
+        retry(10, [this]() {
+            writeCommand(IMSI);
+            if (readCommand(lines) == 2 && isOK(lines[1]) && strnlen(lines[0], 16) == 15)
+            {
+                // Line contains IMSI ("<15 digit IMSI>")
+                memcpy(_imsi, lines[0], strnlen(lines[0], 15) + 1);
+                return true;
+            }
+            return false;
+        });
     }
     return String(_imsi);
 }
@@ -608,4 +613,16 @@ int splitFields(char *line, char **fields, uint8_t maxFields)
         }
     }
     return found;
+}
+
+bool retry(uint8_t attempts, std::function<bool ()> fn, uint16_t delayBetween)
+{
+    while (attempts--)
+    {
+        if (fn()) {
+            return true;
+        }
+        delay(delayBetween);
+    }
+    return false;
 }


### PR DESCRIPTION
Some commands seem to fail quite often and it helps to try again a few times. It's nice to have the library do this dirty work, so the application doesn't need a lot of extra code around every code. The scary thing is that we might also lock up the device if the error is unrecoverable. Say the radio haven't been enabled - which would prevent the imei from being read. Trying to open a socket that is already open would also cause issues.

**Update:** Have changed the while loop with a limited number of retries using lamdas. This should prevent lock-ups and make it easy to use similar retry functionality in other parts of the library.