### PR TITLE
Fix disabling power save mode

### DIFF
--- a/TelenorNBIoT.cpp
+++ b/TelenorNBIoT.cpp
@@ -392,7 +392,8 @@ bool TelenorNBIoT::powerSaveMode(power_save_mode psm)
 {
     m_psm = psm;
 
-    if (m_psm == psm_sleep_after_send || m_psm == psm_sleep_after_response) {
+    if (m_psm == psm_sleep_after_send || m_psm == psm_sleep_after_response)
+    {
         // disable eDRX
         writeCommand("CEDRXS=3,5");
 
@@ -404,12 +405,19 @@ bool TelenorNBIoT::powerSaveMode(power_save_mode psm)
         // Requested Active Time (T3324) - 
         writeCommand("CPSMS=1,,,\"01000001\",\"00000000\"");
         return (readCommand(lines) == 1 && isOK(lines[0]));
-    } else {
+    }
+    else
+    {
         // set eDRX to default value
-        writeCommand("CEDRXS=0");
+        writeCommand("CEDRXS=0,5");
+        if (readCommand(lines) != 1 || !isOK(lines[1]))
+        {
+            return false;
+        }
 
         // disable Power Save Mode and reset all PSM parameters to factory values
         writeCommand("CPSMS=2");
+        return (readCommand(lines) == 1 && isOK(lines[0]));
     }
 }
 


### PR DESCRIPTION
`CEDRXS=0` would always fail, so had to add `5` specifying that we mean NB-IoT - even though it's shown as optional in the AT-commands docs 🙄 

Also, since we didn't read the response, we fired off new commands before the N210 had a chance at responding.