### PR TITLE
Add errorCode method to return error code from last u-blox N210 command

### DIFF
--- a/TelenorNBIoT.cpp
+++ b/TelenorNBIoT.cpp
@@ -58,10 +58,12 @@ bool TelenorNBIoT::begin(Stream &serial)
     reboot();
 
     // Enable error codes for u-blox SARA N2 errors
-    bool errorCodesEnabled = false;
-    while (!errorCodesEnabled) {
+    while (true) {
         writeCommand("CMEE=1");
-        errorCodesEnabled = readCommand(lines) == 1 && isOK(lines[0]);
+        if (readCommand(lines) == 1 && isOK(lines[0])) {
+            break;
+        }
+        delay(100);
     }
 
     return online() &&

--- a/TelenorNBIoT.cpp
+++ b/TelenorNBIoT.cpp
@@ -57,6 +57,13 @@ bool TelenorNBIoT::begin(Stream &serial)
     drain();
     reboot();
 
+    // Enable error codes for u-blox SARA N2 errors
+    bool errorCodesEnabled = false;
+    while (!errorCodesEnabled) {
+        writeCommand("CMEE=1");
+        errorCodesEnabled = readCommand(lines) == 1 && isOK(lines[0]);
+    }
+
     return online() &&
         setNetworkOperator(mcc, mnc) &&
         setAccessPointName(apn);
@@ -248,6 +255,11 @@ int TelenorNBIoT::rssi()
     return -113 + rssi * 2;
 }
 
+int TelenorNBIoT::errorCode()
+{
+    return _errCode;
+}
+
 String TelenorNBIoT::firmwareVersion()
 {
     writeCommand(FIRMWARE);
@@ -436,7 +448,23 @@ bool TelenorNBIoT::isOK(const char *line)
 
 bool TelenorNBIoT::isError(const char *line)
 {
-    return (line[0] == 'E' && line[1] == 'R' && line[2] == 'R' && line[3] == 'O' && line[4] == 'R');
+    int i = 0;
+    if (line[i] == '+') {
+        i = 5;
+    }
+    return (line[i++] == 'E' && line[i++] == 'R' && line[i++] == 'R' && line[i++] == 'O' && line[i++] == 'R');
+}
+
+int TelenorNBIoT::parseErrorCode(const char *line)
+{
+    if (!isError(line)) {
+        return -1;
+    } else if (line[0] != '+') {
+        return -2;
+    }
+    line += 12;
+    int errCode = atoi(line);
+    return errCode;
 }
 
 int TelenorNBIoT::splitFields(char *line, char **fields)
@@ -523,6 +551,7 @@ uint8_t TelenorNBIoT::readCommand(char **lines)
             if (isError(lines[lineno]))
             {
                 completed = true;
+                _errCode = parseErrorCode(lines[lineno]);
             }
 
             lineno++;
@@ -536,6 +565,7 @@ void TelenorNBIoT::writeCommand(const char *cmd)
 {
     uint8_t n = 0;
     drain();
+    _errCode = -1;
     
     ublox->print(PREFIX);
     ublox->print(cmd);

--- a/TelenorNBIoT.h
+++ b/TelenorNBIoT.h
@@ -142,6 +142,12 @@ class TelenorNBIoT
     int rssi();
 
     /**
+     * Get the error code of the previous command. See Appendix A in the SARA
+     * N2 AT Commands guide for the description of each error code.
+     */
+    int errorCode();
+
+    /**
      * Returns the u-blox SARA firmware Version
      */
     String firmwareVersion();
@@ -169,6 +175,7 @@ class TelenorNBIoT
     char buffer[BUFSIZE];
     char *lines[MAXLINES];
     power_save_mode m_psm;
+    int _errCode = -1;
 
     bool dataOn();
     uint8_t readCommand(char **lines);
@@ -178,6 +185,7 @@ class TelenorNBIoT
     bool setAccessPointName(const char *accessPointName);
     bool isOK(const char *line);
     bool isError(const char *line);
+    int parseErrorCode(const char *line);
     int splitFields(char *line, char **fields);
     void hexToBytes(const char *hex, const uint16_t byte_count, char *bytes);
     void writeBuffer(const char *data, uint16_t length);


### PR DESCRIPTION
Enable error codes in the error responses from u-blox N2. Store the code from the last command and expose a method to return the error code to the user.

This can be used for debugging or for better error handling.